### PR TITLE
allow multiple host instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,11 @@
 *.dll
 *.so
 *.dylib
+*~
 
 # Test binary, built with `go test -c`
 *.test
+*.wasm
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: clean test testdata
+
+testdata.wat = $(wildcard testdata/*.wat)
+testdata.wasm = $(testdata.wat:.wat=.wasm)
+
+test: testdata
+	go test -v ./...
+
+testdata: $(testdata.wasm)
+
+clean:
+	rm -f $(testdata.wasm)
+
+%.wasm: %.wat
+	wat2wasm -o $@ $<

--- a/module.go
+++ b/module.go
@@ -196,11 +196,12 @@ func (m *ModuleInstance[T]) ExportedGlobal(name string) api.Global {
 }
 
 func (m *ModuleInstance[T]) Close(ctx context.Context) error {
+	m.module = nil
 	return m.instance.Close(ctx)
 }
 
 func (m *ModuleInstance[T]) CloseWithExitCode(ctx context.Context, _ uint32) error {
-	return m.instance.Close(ctx)
+	return m.Close(ctx)
 }
 
 var (

--- a/module.go
+++ b/module.go
@@ -160,8 +160,8 @@ func (m *ModuleInstance[T]) Memory() api.Memory {
 
 func (m *ModuleInstance[T]) ExportedFunction(name string) api.Function {
 	if m.module != nil {
-		if fn := m.module.ExportedFunction(name); fn != nil {
-			return &moduleInstanceFunction[T]{fn, m}
+		if f := m.module.ExportedFunction(name); f != nil {
+			return &moduleInstanceFunction[T]{f, m}
 		}
 	}
 	return nil

--- a/module_test.go
+++ b/module_test.go
@@ -1,0 +1,91 @@
+package wazergo_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stealthrocket/wazergo"
+	. "github.com/stealthrocket/wazergo/types"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+)
+
+var hostModule wazergo.HostModule[*hostInstance] = hostFunctions{
+	"answer": wazergo.F0((*hostInstance).Answer),
+}
+
+type hostFunctions wazergo.Functions[*hostInstance]
+
+func (m hostFunctions) Name() string {
+	return "test"
+}
+
+func (m hostFunctions) Functions() wazergo.Functions[*hostInstance] {
+	return (wazergo.Functions[*hostInstance](m))
+}
+
+func (m hostFunctions) Instantiate(ctx context.Context, opts ...wazergo.Option[*hostInstance]) (*hostInstance, error) {
+	ins := new(hostInstance)
+	wazergo.Configure(ins, opts...)
+	return ins, nil
+}
+
+type hostInstance struct {
+	answer int
+}
+
+func (m *hostInstance) Close(ctx context.Context) error {
+	return nil
+}
+
+func (m *hostInstance) Answer(ctx context.Context) Int32 {
+	return Int32(m.answer)
+}
+
+func answer(a int) wazergo.Option[*hostInstance] {
+	return wazergo.OptionFunc(func(m *hostInstance) { m.answer = a })
+}
+
+func TestMultipleHostModuleInstances(t *testing.T) {
+	ctx := context.Background()
+
+	runtime := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
+		WithDebugInfoEnabled(true).
+		WithCustomSections(true),
+	)
+	defer runtime.Close(ctx)
+
+	// three copies, all share the same host module name but different state
+	instance0 := wazergo.MustInstantiate(ctx, runtime, hostModule, answer(0))
+	instance1 := wazergo.MustInstantiate(ctx, runtime, hostModule, answer(21))
+	instance2 := wazergo.MustInstantiate(ctx, runtime, hostModule, answer(42))
+
+	guest, err := loadModule(ctx, runtime, "testdata/answer.wasm")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	answer := guest.ExportedFunction("answer")
+	r0, _ := answer.Call(wazergo.WithModuleInstance(ctx, instance0))
+	r1, _ := answer.Call(wazergo.WithModuleInstance(ctx, instance1))
+	r2, _ := answer.Call(wazergo.WithModuleInstance(ctx, instance2))
+
+	for i, test := range [...]struct{ want, got int }{
+		{want: 0, got: int(r0[0])},
+		{want: 21, got: int(r1[0])},
+		{want: 42, got: int(r2[0])},
+	} {
+		if test.want != test.got {
+			t.Errorf("result %d is wrong: want=%d got=%d", i, test.want, test.got)
+		}
+	}
+}
+
+func loadModule(ctx context.Context, runtime wazero.Runtime, filePath string) (api.Module, error) {
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	return runtime.Instantiate(ctx, b)
+}

--- a/module_test.go
+++ b/module_test.go
@@ -66,6 +66,7 @@ func TestMultipleHostModuleInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer guest.Close(ctx)
 
 	answer := guest.ExportedFunction("answer")
 	r0, _ := answer.Call(wazergo.WithModuleInstance(ctx, instance0))

--- a/module_test.go
+++ b/module_test.go
@@ -58,6 +58,10 @@ func TestMultipleHostModuleInstances(t *testing.T) {
 	instance1 := wazergo.MustInstantiate(ctx, runtime, hostModule, answer(21))
 	instance2 := wazergo.MustInstantiate(ctx, runtime, hostModule, answer(42))
 
+	defer instance0.Close(ctx)
+	defer instance1.Close(ctx)
+	defer instance2.Close(ctx)
+
 	guest, err := loadModule(ctx, runtime, "testdata/answer.wasm")
 	if err != nil {
 		t.Fatal(err)

--- a/module_test.go
+++ b/module_test.go
@@ -50,10 +50,7 @@ func answer(a int) wazergo.Option[*hostInstance] {
 func TestMultipleHostModuleInstances(t *testing.T) {
 	ctx := context.Background()
 
-	runtime := wazero.NewRuntimeWithConfig(ctx, wazero.NewRuntimeConfig().
-		WithDebugInfoEnabled(true).
-		WithCustomSections(true),
-	)
+	runtime := wazero.NewRuntime(ctx)
 	defer runtime.Close(ctx)
 
 	// three copies, all share the same host module name but different state

--- a/testdata/answer.wat
+++ b/testdata/answer.wat
@@ -1,0 +1,6 @@
+(module
+  (type (;0;) (func (result i32)))
+  (import "test" "answer" (func $__imported_answer (type 0)))
+  (func $answer (type 0) (result i32)
+    call $__imported_answer)
+  (export "answer" (func $answer)))


### PR DESCRIPTION
Following up from our discussion in the wazero slack, this PR modifies wazergo to allow the creation of multiple host module instances, which is useful when the state of a host module needs to be scoped to the lifetime of a guest module.

@lthibault 