### PR TITLE
types: add NewList helper

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -789,6 +789,12 @@ type List[T Object[T]] struct {
 	len uint32
 }
 
+// NewList constructs a list from a pointer to an object of type T
+// and a length.
+func NewList[T Object[T]](ptr Pointer[T], length int) List[T] {
+	return List[T]{ptr, uint32(length)}
+}
+
 func (arg List[T]) FormatValue(w io.Writer, memory api.Memory, stack []uint64) {
 	fmt.Fprintf(w, "[")
 	arg = arg.LoadValue(memory, stack)

--- a/types/types.go
+++ b/types/types.go
@@ -789,9 +789,9 @@ type List[T Object[T]] struct {
 	len uint32
 }
 
-// NewList constructs a list from a pointer to an object of type T
+// MakeList constructs a list from a pointer to an object of type T
 // and a length.
-func NewList[T Object[T]](ptr Pointer[T], length int) List[T] {
+func MakeList[T Object[T]](ptr Pointer[T], length int) List[T] {
 	return List[T]{ptr, uint32(length)}
 }
 


### PR DESCRIPTION
This is to implement a host import like the `poll_oneoff` function from WASI preview 1.

The `List[T]` param works nicely when your host import has a `(ptr, count)` pair. Sometimes multiple lists may be specified, for example an input list (WASI subscriptions) and an output list (WASI events). Having a `NewList` constructor helps in these cases (e.g. allowing you to accept `(inptr, outptr, count)` rather than `(inptr, incount, outptr, outcount)`).