### PR TITLE
types: add helpers to convert from List[T] and Pointer[T] to []T

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -779,6 +779,13 @@ func (arg Pointer[T]) Index(index int) Pointer[T] {
 	return Pointer[T]{arg.memory, arg.offset + uint32(index*objectSize[T]())}
 }
 
+func (arg Pointer[T]) Append(buffer []T, count int) []T {
+	for i := 0; i < count; i++ {
+		buffer = append(buffer, arg.Index(i).Load())
+	}
+	return buffer
+}
+
 var (
 	_ Param[Pointer[None]] = Pointer[None]{}
 )
@@ -837,6 +844,13 @@ func (arg List[T]) Range(fn func(int, T) bool) {
 			break
 		}
 	}
+}
+
+func (arg List[T]) Append(buffer []T) []T {
+	if arg.Len() == 0 {
+		return buffer
+	}
+	return arg.Index(0).Append(buffer, arg.Len())
 }
 
 var (

--- a/types/types.go
+++ b/types/types.go
@@ -786,6 +786,10 @@ func (arg Pointer[T]) Append(buffer []T, count int) []T {
 	return buffer
 }
 
+func (arg Pointer[T]) Slice(count int) []T {
+	return arg.Append(nil, count)
+}
+
 func (arg Pointer[T]) UnsafeSlice(count int) []T {
 	if count == 0 {
 		return nil
@@ -861,6 +865,10 @@ func (arg List[T]) Append(buffer []T) []T {
 		return buffer
 	}
 	return arg.Index(0).Append(buffer, arg.Len())
+}
+
+func (arg List[T]) Slice() []T {
+	return arg.Append(nil)
 }
 
 func (arg List[T]) UnsafeSlice() []T {

--- a/types/types.go
+++ b/types/types.go
@@ -797,7 +797,7 @@ func (arg Pointer[T]) UnsafeSlice(count int) []T {
 	var t T
 	size := t.ObjectSize()
 	data := wasm.Read(arg.memory, arg.offset, uint32(count*size))
-	return unsafe.Slice(*(**T)(unsafe.Pointer(&data)), count)
+	return unsafe.Slice((*T)(unsafe.Pointer(&data)), count)
 }
 
 var (

--- a/types/types.go
+++ b/types/types.go
@@ -786,6 +786,16 @@ func (arg Pointer[T]) Append(buffer []T, count int) []T {
 	return buffer
 }
 
+func (arg Pointer[T]) UnsafeSlice(count int) []T {
+	if count == 0 {
+		return nil
+	}
+	var t T
+	size := t.ObjectSize()
+	data := wasm.Read(arg.memory, arg.offset, uint32(count*size))
+	return unsafe.Slice(*(**T)(unsafe.Pointer(&data)), count)
+}
+
 var (
 	_ Param[Pointer[None]] = Pointer[None]{}
 )
@@ -851,6 +861,13 @@ func (arg List[T]) Append(buffer []T) []T {
 		return buffer
 	}
 	return arg.Index(0).Append(buffer, arg.Len())
+}
+
+func (arg List[T]) UnsafeSlice() []T {
+	if arg.Len() == 0 {
+		return nil
+	}
+	return arg.Index(0).UnsafeSlice(arg.Len())
 }
 
 var (


### PR DESCRIPTION
Sometimes we need to accept a list of items of type `T` and then pass a `[]T` slice to some other function. This PR adds two ways to convert `List[T]` and `Pointer[T]` to `[]T`.

The first way — `Append` — is safe in all cases; it calls `Pointer[T].Load()` for all items, in case the `Object[T].LoadObject` implementation does conversions. The `Append` function accepts a buffer so that zero allocation conversions are possible.

The second way — `UnsafeSlice` — is only safe in some cases, where `T` in the guest memory can directly be cast to `T` in the host memory. There are cases where the cast is invalid, for example when `T` contains interior pointers, or when the guest/host don't agree on endianness. For this reason, the function has an `Unsafe` prefix.