### PR TITLE
types: fix invalid UnsafeSlice cast

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -883,12 +883,12 @@ func (arg Pointer[T]) Slice(count int) []T {
 
 func (arg Pointer[T]) UnsafeSlice(count int) []T {
 	var typ T
-	if count == 0 {
+	size := typ.ObjectSize()
+	if count == 0 || size == 0 {
 		return nil
 	}
-	size := typ.ObjectSize()
 	data := wasm.Read(arg.memory, arg.offset, uint32(count*size))
-	return unsafe.Slice((*T)(unsafe.Pointer(&data)), count)
+	return unsafe.Slice((*T)(unsafe.Pointer(&data[0])), count)
 }
 
 var (


### PR DESCRIPTION
`Pointer[T].UnsafeSlice` was casting the slice pointer rather than the slice data pointer to `*T`. This PR fixes the bug.